### PR TITLE
Bump up the clock period for simulation

### DIFF
--- a/Scripts/credit_based/network_tb_gen_parameterized_credit_based.py
+++ b/Scripts/credit_based/network_tb_gen_parameterized_credit_based.py
@@ -343,7 +343,7 @@ if not add_SHMU:
   noc_file.write("\tsignal Reconfig: std_logic := '0';\n")
 
 noc_file.write("\t--------------\n")
-noc_file.write("\tconstant clk_period : time := 1 ns;\n")
+noc_file.write("\tconstant clk_period : time := 10 ns;\n")
 noc_file.write("\tsignal reset, not_reset, clk: std_logic :='0';\n")
 
 noc_file.write("\n")


### PR DESCRIPTION
Any chance we can do this upstream? I was reluctant to just change it because it will influence results of any simulation (as now the clock is slower). However, I'm a bit tired of using a workaround for myself, so I'm wondering if we can just get it done in the repo.