### PR TITLE
Add -c flag for command-line simulation

### DIFF
--- a/Scripts/include/arg_parser.py
+++ b/Scripts/include/arg_parser.py
@@ -111,6 +111,9 @@ def arg_parser(argv, program_argv, logging):
     if '-verilog' in argv[1:]:
         program_argv['verilog'] = True
 
+    if '-c' in argv[1:]:
+        program_argv['command-line'] = True
+
     logging.info("Finished parsing program arguments")
     logging.info("Command line parameters:")
     for i in program_argv:

--- a/Scripts/include/package.py
+++ b/Scripts/include/package.py
@@ -61,6 +61,7 @@ program_argv = {
         'debug':           False,
         'trace':           False,
         'verilog':         False,
+        'command-line':    False,
     }
 
 # Debug mode is off by default

--- a/Scripts/include/write_do_file.py
+++ b/Scripts/include/write_do_file.py
@@ -243,7 +243,7 @@ def write_do_file(program_argv, net_file_name, net_tb_file_name, wave_do_file_na
         else:
             do_file.write("run " + str(program_argv['end']) + " ns\n")
 
-    if program_argv['lat']:
+    if program_argv['command-line'] or program_argv['lat']:
         do_file.write("\n# Exit Modelsim after simulation\n")
         do_file.write("exit\n")
     do_file.close()

--- a/simulate.py
+++ b/simulate.py
@@ -86,8 +86,9 @@ def main(argv):
     if DEBUG: print_msg(MSG_DEBUG, "Running Modelsim...")
 
     os.chdir(package.SIMUL_DIR)
-    if package.program_argv['lat']:
-        return_value = os.system("vsim -c -do " + package.SIMUL_DO_SCRIPT)
+    if package.program_argv['command-line'] or package.program_argv['lat']:
+        novopt = '-novopt ' if package.program_argv['verilog'] else ''
+        return_value = os.system("vsim -c " + novopt + "-do " + package.SIMUL_DO_SCRIPT)
     else:
         return_value = os.system("vsim -do " + package.SIMUL_DO_SCRIPT)
 


### PR DESCRIPTION
It simply won't run the GUI if -c flag is present.

If vcd branch is merged, then it will be possible to view the results
from wave.vcd file.

Maybe we should always include -novopt flag. Or maybe it should be
configurable.

See also issue #28.